### PR TITLE
update market-movers endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -704,7 +704,6 @@ Retrieves a list of the top market movers.
 ```typescript
 client
   .getStocksMarketMovers({
-    by: "change",
     top: 10,
   })
   .then(console.log);

--- a/api/marketData.ts
+++ b/api/marketData.ts
@@ -253,7 +253,6 @@ export const getStocksMostActives =
     });
 
 export type GetStocksMarketMoversOptions = {
-  by?: string;
   top?: number;
 };
 

--- a/api/marketData.ts
+++ b/api/marketData.ts
@@ -261,7 +261,7 @@ export const getStocksMarketMovers =
   (context: ClientContext) => (params: GetStocksMarketMoversOptions) =>
     context.request<MarketMovers>({
       baseURL: baseURLs.marketData,
-      path: "/v1beta1/screener/stocks/market-movers",
+      path: "/v1beta1/screener/stocks/movers",
       method: "GET",
       params,
     });


### PR DESCRIPTION
The current endpoint returns `not found`.
It should be `/movers` instead of `/market-movers`.

Also, I don't see why there is a `by: "change"` option as I could not find any documentation for it.

---

Note: I just arrived here and I couldn't make anything work without #11. I highly recommend  @117 take a look at it asap.